### PR TITLE
resolve several issues found by cppcheck

### DIFF
--- a/libraries/libreldap/ntlm.c
+++ b/libraries/libreldap/ntlm.c
@@ -100,13 +100,13 @@ ldap_parse_ntlm_bind_result(
 
 	Debug( LDAP_DEBUG_TRACE, "ldap_parse_ntlm_bind_result\n" );
 
-	assert( ld != NULL );
-	assert( LDAP_VALID( ld ) );
-	assert( res != NULL );
-
 	if ( ld == NULL || res == NULL ) {
 		return LDAP_PARAM_ERROR;
 	}
+
+        assert( ld != NULL );
+        assert( LDAP_VALID( ld ) );
+        assert( res != NULL );
 
 	if( res->lm_msgtype != LDAP_RES_BIND ) {
 		ld->ld_errno = LDAP_PARAM_ERROR;

--- a/libraries/libreldap/sortctrl.c
+++ b/libraries/libreldap/sortctrl.c
@@ -279,9 +279,11 @@ ldap_create_sort_control_value(
 	ber_tag_t	tag;
 
 	assert( ld != NULL );
-	assert( LDAP_VALID( ld ) );
 
 	if ( ld == NULL ) return LDAP_PARAM_ERROR;
+
+	assert( LDAP_VALID( ld ) );
+
 	if ( keyList == NULL || value == NULL ) {
 		ld->ld_errno = LDAP_PARAM_ERROR;
 		return LDAP_PARAM_ERROR;
@@ -396,11 +398,12 @@ ldap_create_sort_control(
 	struct berval	value;
 
 	assert( ld != NULL );
-	assert( LDAP_VALID( ld ) );
 
 	if ( ld == NULL ) {
 		return LDAP_PARAM_ERROR;
 	}
+
+	assert( LDAP_VALID( ld ) );
 
 	if ( ctrlp == NULL ) {
 		ld->ld_errno = LDAP_PARAM_ERROR;
@@ -479,11 +482,12 @@ ldap_parse_sortresponse_control(
 	ber_len_t berLen;
 
 	assert( ld != NULL );
-	assert( LDAP_VALID( ld ) );
 
 	if (ld == NULL) {
 		return LDAP_PARAM_ERROR;
 	}
+
+	assert( LDAP_VALID( ld ) );
 
 	if (ctrl == NULL) {
 		ld->ld_errno =  LDAP_PARAM_ERROR;

--- a/servers/slapd/slapi/slapi_overlay.c
+++ b/servers/slapd/slapi/slapi_overlay.c
@@ -45,12 +45,11 @@ slapi_over_pblock_new( Operation *op, SlapReply *rs )
 	Slapi_PBlock		*pb;
 
 	pb = slapi_pblock_new();
+	PBLOCK_ASSERT_OP( pb, op->o_tag );
 	pb->pb_op = op;
 	pb->pb_conn = op->o_conn;
 	pb->pb_rs = rs;
 	pb->pb_intop = 0;
-
-	PBLOCK_ASSERT_OP( pb, op->o_tag );
 
 	return pb;
 }


### PR DESCRIPTION
[servers/slapd/slapi/slapi_overlay.c:48] -> [servers/slapd/slapi/slapi_overlay.c:53]: (warning) Either the condition '(pb)!=NULL' is redundant or there is possible null pointer dereference: pb.
[servers/slapd/slapi/slapi_overlay.c:49] -> [servers/slapd/slapi/slapi_overlay.c:53]: (warning) Either the condition '(pb)!=NULL' is redundant or there is possible null pointer dereference: pb.
[servers/slapd/slapi/slapi_overlay.c:50] -> [servers/slapd/slapi/slapi_overlay.c:53]: (warning) Either the condition '(pb)!=NULL' is redundant or there is possible null pointer dereference: pb.
[servers/slapd/slapi/slapi_overlay.c:51] -> [servers/slapd/slapi/slapi_overlay.c:53]: (warning) Either the condition '(pb)!=NULL' is redundant or there is possible null pointer dereference: pb.

[libraries/libreldap/ntlm.c:104] -> [libraries/libreldap/ntlm.c:107]: (warning) Either the condition 'ld==NULL' is redundant or there is possible null pointer dereference: ld.