### PR TITLE
Fix ldap_dirs.h issue 

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -278,7 +278,6 @@ AH_BOTTOM([
 
 AC_CONFIG_HEADERS([reldap_autoconf.h])
 AC_CONFIG_HEADERS([include/ldap_features.h])
-AC_CONFIG_HEADERS([include/ldap_dirs.h])
 AC_CONFIG_HEADERS([include/lber_types.h])
 
 dnl ================================================================

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -30,8 +30,9 @@ noinst_HEADERS = ac/alloca.h ac/bytes.h ac/crypt.h ac/ctype.h \
 BUILT_SOURCES = ldap_dirs.h
 CLEANFILES = ldap_dirs.h
 EXTRA_DIST = ldap_dirs.h.in
+LDAP_DIRS = $(srcdir)/ldap_dirs.h.in
 
-ldap_dirs.h: $(srcdir)/ldap_dirs.h.in Makefile
+ldap_dirs.h: $(LDAP_DIRS) Makefile
 	@if $(AM_V_P); then set -x; else echo "  GEN      $@"; fi; \
 	$(RM) $@ && \
 	echo "/* Generated from $< on `date --rfc-3339=seconds --utc` */" > $@ && \


### PR DESCRIPTION
@variables@ are not replaced with paths on autoconf 2.69.191, automake 1.15 and make 4.1 and built image trying to access @sysconfdir@ and @localstatedir@ directory (and fails on start with -h ldapi:///)

Build environment: Docker (debian:stretch) or ubuntu 17.04
Steps to reproduce:
```
./bootstrap.sh
./configure --enable-local
make all
make install
cd /opt/reopenldap/sbin
./slapd -h ldapi:///
```